### PR TITLE
Add documentation for ignore_attachments field

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,3 +103,20 @@ To use HTTPS, pass the **protocol** field. Most likely, you will also have to ch
 	        "no_verify" : "true"
 	    }
 	}
+
+
+Ignoring Attachments
+====================
+
+You can ignore attachments as provided by couchDb for each document (`_attachments` field).
+
+Here is an example setting that disable *attachments* for all docs:
+
+	{
+	  "type":"couchdb",
+	  "couchdb": {
+	    "ignore_attachments":true
+	  }
+	}
+
+Note, by default, attachments are not ignored (**false**)


### PR DESCRIPTION
Relative to https://github.com/elasticsearch/elasticsearch.github.com/pull/72 and
https://github.com/elasticsearch/elasticsearch/pull/1283 : add
documentation for ignore_attachments field
