### PR TITLE
Update couchDb river plugin for ES 0.19.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,15 +3,17 @@ CouchDB River Plugin for ElasticSearch
 
 The CouchDB River plugin allows to hook into couchdb `_changes` feed and automatically index it into elasticsearch.
 
-In order to install the plugin, simply run: `bin/plugin -install elasticsearch/elasticsearch-river-couchdb/1.0.0`.
+In order to install the plugin, simply run: `bin/plugin -install elasticsearch/elasticsearch-river-couchdb/1.1.0`.
 
-    ---------------------------------------
-    | memcached Plugin | ElasticSearch    |
-    ---------------------------------------
-    | master           | 0.18 -> master   |
-    ---------------------------------------
-    | 1.0.0            | 0.18 -> master   |
-    ---------------------------------------
+    -------------------------------------
+    | CouchDB Plugin | ElasticSearch    |
+    -------------------------------------
+    | master         | 0.19 -> master   |
+    -------------------------------------
+    | 1.0.0          | 0.18             |
+    -------------------------------------
+    | 1.1.0          | 0.19 -> master   |
+    -------------------------------------
 
 The CouchDB River allows to automatically index couchdb and make it searchable using the excellent [_changes](http://guide.couchdb.org/draft/notifications.html) stream couchdb provides. Setting it up is as simple as executing the following against elasticsearch:
 
@@ -103,3 +105,20 @@ To use HTTPS, pass the **protocol** field. Most likely, you will also have to ch
 	        "no_verify" : "true"
 	    }
 	}
+
+
+Ignoring Attachments
+====================
+
+You can ignore attachments as provided by couchDb for each document (`_attachments` field).
+
+Here is an example setting that disable *attachments* for all docs:
+
+	{
+	  "type":"couchdb",
+	  "couchdb": {
+	    "ignore_attachments":true
+	  }
+	}
+
+Note, by default, attachments are not ignored (**false**)

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
     </parent>
 
     <properties>
-        <elasticsearch.version>0.18.5</elasticsearch.version>
+        <elasticsearch.version>0.19.0</elasticsearch.version>
     </properties>
 
     <repositories>

--- a/src/main/java/org/elasticsearch/river/couchdb/CouchdbRiver.java
+++ b/src/main/java/org/elasticsearch/river/couchdb/CouchdbRiver.java
@@ -19,32 +19,15 @@
 
 package org.elasticsearch.river.couchdb;
 
-import org.elasticsearch.ExceptionsHelper;
-import org.elasticsearch.action.bulk.BulkResponse;
-import org.elasticsearch.action.get.GetResponse;
-import org.elasticsearch.client.Client;
-import org.elasticsearch.client.action.bulk.BulkRequestBuilder;
-import org.elasticsearch.cluster.block.ClusterBlockException;
-import org.elasticsearch.common.Base64;
-import org.elasticsearch.common.collect.Maps;
-import org.elasticsearch.common.inject.Inject;
-import org.elasticsearch.common.io.Closeables;
-import org.elasticsearch.common.unit.TimeValue;
-import org.elasticsearch.common.util.concurrent.EsExecutors;
-import org.elasticsearch.common.util.concurrent.jsr166y.LinkedTransferQueue;
-import org.elasticsearch.common.xcontent.XContentBuilder;
-import org.elasticsearch.common.xcontent.XContentFactory;
-import org.elasticsearch.common.xcontent.XContentType;
-import org.elasticsearch.common.xcontent.support.XContentMapValues;
-import org.elasticsearch.indices.IndexAlreadyExistsException;
-import org.elasticsearch.river.*;
-import org.elasticsearch.script.ExecutableScript;
-import org.elasticsearch.script.ScriptService;
+import static org.elasticsearch.client.Requests.deleteRequest;
+import static org.elasticsearch.client.Requests.indexRequest;
+import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
 
-import javax.net.ssl.HostnameVerifier;
-import javax.net.ssl.HttpsURLConnection;
-import javax.net.ssl.SSLSession;
-import java.io.*;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.UnsupportedEncodingException;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.net.URLEncoder;
@@ -54,9 +37,37 @@ import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.TimeUnit;
 
-import static org.elasticsearch.client.Requests.deleteRequest;
-import static org.elasticsearch.client.Requests.indexRequest;
-import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
+import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.HttpsURLConnection;
+import javax.net.ssl.SSLSession;
+
+import jsr166y.LinkedTransferQueue;
+
+import org.elasticsearch.ExceptionsHelper;
+import org.elasticsearch.action.bulk.BulkRequestBuilder;
+import org.elasticsearch.action.bulk.BulkResponse;
+import org.elasticsearch.action.get.GetResponse;
+import org.elasticsearch.client.Client;
+import org.elasticsearch.cluster.block.ClusterBlockException;
+import org.elasticsearch.common.Base64;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.common.util.concurrent.EsExecutors;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.common.xcontent.XContentType;
+import org.elasticsearch.common.xcontent.support.XContentMapValues;
+import org.elasticsearch.indices.IndexAlreadyExistsException;
+import org.elasticsearch.river.AbstractRiverComponent;
+import org.elasticsearch.river.River;
+import org.elasticsearch.river.RiverIndexName;
+import org.elasticsearch.river.RiverName;
+import org.elasticsearch.river.RiverSettings;
+import org.elasticsearch.script.ExecutableScript;
+import org.elasticsearch.script.ScriptService;
+
+import com.google.common.collect.Maps;
+import com.google.common.io.Closeables;
 
 /**
  *


### PR DESCRIPTION
As described here : https://github.com/elasticsearch/elasticsearch/issues/1611
Here is an update to let the CouchDb plugin works with 0.19.0

Don't merge this pull request before releasing 0.19.0 version of Elasticsearch as the pom.xml use it.

Hope this helps
