### PR TITLE
Support for changing id via script

### DIFF
--- a/src/main/java/org/elasticsearch/river/couchdb/CouchdbRiver.java
+++ b/src/main/java/org/elasticsearch/river/couchdb/CouchdbRiver.java
@@ -247,6 +247,8 @@ public class CouchdbRiver extends AbstractRiverComponent implements River {
             }
         }
 
+        id = (ctx.get("id") == null) ? null : ctx.get("id").toString();
+
         if (ctx.containsKey("ignore") && ctx.get("ignore").equals(Boolean.TRUE)) {
             // ignore dock
         } else if (ctx.containsKey("deleted") && ctx.get("deleted").equals(Boolean.TRUE)) {


### PR DESCRIPTION
I know two ways to change id.
1. The simply way:
   
   ```
   "script": "ctx.id = ctx.doc._id = ctx.doc.new_id;"
   ```
2. Associate the _id mapping with a path:
   
   ```
   {
      "mappings": {
          "my_type": {
              "_id": {"path": "new_id"},
          }
      }
   }
   ```
   
   and set id to null:
   
   ```
   "script": "ctx.id = ctx.doc._id = null;"
   ```

But in both cases a river doesn't change id keeping it always as the couchdb's id.

This patch fixed the issue.
