### PR TITLE
Allow _id overwrite using script

### DIFF
--- a/src/main/java/org/elasticsearch/river/couchdb/CouchdbRiver.java
+++ b/src/main/java/org/elasticsearch/river/couchdb/CouchdbRiver.java
@@ -297,6 +297,16 @@ public class CouchdbRiver extends AbstractRiverComponent implements River {
                 return seq;
             }
         }
+        
+        //update doc id if it was overwritten
+        if (ctx.containsKey("doc")) {
+            oId = ((Map<String, Object>) ctx.get("doc")).get("_id");
+            if (oId != null && !id.equals(oId.toString())) {
+                id = oId.toString();
+                ctx.put("id", id);
+            }
+        }
+
 
         if (ctx.containsKey("ignore") && ctx.get("ignore").equals(Boolean.TRUE)) {
             // ignore dock

--- a/src/test/java/org/elasticsearch/river/couchdb/CouchdbRiverIntegrationTest.java
+++ b/src/test/java/org/elasticsearch/river/couchdb/CouchdbRiverIntegrationTest.java
@@ -230,6 +230,28 @@ public class CouchdbRiverIntegrationTest extends ElasticsearchIntegrationTest {
         assertThat(response.getHits().getAt(0).field("newfield").getValue().toString(), is("bar"));
     }
 
+    @Test
+    public void testScriptingIdOverwrite() throws IOException, InterruptedException {
+        launchTest(jsonBuilder()
+                .startObject()
+                .field("type", "couchdb")
+                .startObject("couchdb")
+                .field("script", "ctx.doc._id_old = ctx.doc._id; ctx.doc._id = ctx.doc._id + '_' + ctx.doc._rev;")
+                .endObject()
+                .endObject(), 1, null);
+
+        SearchResponse response = client().prepareSearch(getDbName())
+                .addField("_id")
+                .addField("_id_old")
+                .addField("_rev")
+                .get();
+
+        String composedId = response.getHits().getAt(0).field("_id_old").getValue().toString()
+                + "_"
+                +  response.getHits().getAt(0).field("_rev").getValue().toString();
+        assertThat(response.getHits().getAt(0).field("_id").getValue().toString(), is(composedId));
+    }
+
     /**
      * Test case for #44: https://github.com/elasticsearch/elasticsearch-river-couchdb/issues/44
      */


### PR DESCRIPTION
This change allows users to overwrite the _id field of documents, and
have it used by ElasticSearch.

This is specially useful for saving the revision history of CouchDB documents.